### PR TITLE
add package to dockerfile to include shasum

### DIFF
--- a/docker/Dockerfile.ubi.amd64
+++ b/docker/Dockerfile.ubi.amd64
@@ -18,7 +18,7 @@ ARG ARCH
 # Set up certificates, our base tools, and Vault.
 RUN set -eux; \
     microdnf update -y; \
-    microdnf install -y ca-certificates shadow-utils gnupg openssl libcap wget tzdata unzip && \
+    microdnf install -y ca-certificates shadow-utils gnupg openssl libcap wget tzdata unzip perl-Digest-SHA && \
     found=''; \
     for server in \
         hkp://p80.pool.sks-keyservers.net:80 \


### PR DESCRIPTION
makes for easier sha256 generation for plugin importing without copying the binary around.