### PR TITLE
changed default secret name and unseal key pathing

### DIFF
--- a/docker/scripts/auto-unseal.sh
+++ b/docker/scripts/auto-unseal.sh
@@ -2,7 +2,7 @@
 unsealed=false
 
 if [ "$VAULT_KEYS" == "" ];then 
-  VAULT_KEYS=ibm-cp-vault-keys
+  VAULT_KEYS=ibm-edge-auth
 fi
 vault_keys=$VAULT_KEYS
 
@@ -20,7 +20,7 @@ do
   else 
 
     set +x
-    keys=`kubectl get secret $vault_keys -o=jsonpath='{.data.keys}'|base64 -d`
+    keys=`kubectl get secret $vault_keys -o=jsonpath='{.data.vault-unseal-keys}'|base64 -d`
     IFS=$',' keys=( $keys )
     for var in ${keys[@]}  
     do    


### PR DESCRIPTION
changed default secret name to ibm-edge-auth (overrided in the operator regardless).
changed unseal key path within the secret.

This PR needs to be approved and merged at the same time as an equivalent one in the operator repo (internal github) and the bootstrap repo (internal github).