### PR TITLE
Devops-issue-46: Affixed the vault user/group to uid:gid 1000:1000

### DIFF
--- a/docker/Dockerfile.ubi.amd64
+++ b/docker/Dockerfile.ubi.amd64
@@ -50,8 +50,8 @@ RUN set -eux; \
 # /vault/logs is made available to use as a location to store audit logs
 # /vault/file is made available to use as a location with the file storage backend
 # the server will be started with /vault/config as the configuration directory so you can add additional config files in that location.
-RUN groupadd -g 1001 vault && \
-    useradd -rm -u 1001 -g vault vault
+RUN groupadd -g 1000 vault && \
+    useradd -rm -u 1000 -g vault vault
 ENV VAULT_PLUGIN_HASH ${VAULT_PLUGIN_HASH}
 ENV HOME /home/vault
 RUN mkdir -p /vault/logs && \


### PR DESCRIPTION
References: Issue 46 in the open-horizon/devops project: https://github.com/open-horizon/devops/issues/46

Changes:
- Affixed the vault user/group to uid:gid 1000:1000. Allows Vault to write back to a host directory in a docker environment.