### PR TITLE
Security vulnerability updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 arch_tag ?= $(shell ./tools/arch-tag)
 arch ?= $(arch_tag)
 
-VAULT_VERSION ?= 1.12.0
+VAULT_VERSION ?= 1.12.2
 VAULT_GPGKEY ?= C874011F0AB405110D02105534365D9472D7468F
 VAULT_PLUGIN_HASH := ""
 

--- a/docker/Dockerfile.ubi.amd64
+++ b/docker/Dockerfile.ubi.amd64
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
+FROM registry.access.redhat.com/ubi9-minimal:latest
 
 LABEL vendor="IBM"
 LABEL summary="The secrets vault."


### PR DESCRIPTION
Update to latest 1.12.2 Vault version and use latest UBI9 minimal base image.