### PR TITLE
Issue #60 - Bug: Actions workflow pushes docker images to GitHub cont…

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -10,6 +10,7 @@ on:
 # Variables available to all jobs
 env:
   IMAGE_REPO: ${{ vars.DOCKERHUB_REPO }}
+  GITHUB_CONTAINER_REGISTRY: ghcr.io/${{ github.repository_owner }}
   RUN_NUMBER: ${{ github.run_number }}
   RUN_NUMBER_OFFSET: ${{ vars.RUN_NUMBER_OFFSET }}
 
@@ -28,11 +29,34 @@ jobs:
 
     # Executed sequentially when job runs
     steps:
+      - name: Check User Set Variables
+        run: |
+          if [[ -z "$DOCKER_USER" ]]; then \
+          echo "::error::Secret DOCKER_USER was not set"; \
+          exit 1; \
+          fi
+          if [[ -z "$DOCKER_TOKEN" ]]; then \
+          echo "::error::Secret DOCKER_TOKEN was not set"; \
+          exit 1; \
+          fi
+          if [[ -z "$IMAGE_REPO" ]]; then \
+          echo "::error::Variable DOCKERHUB_REPO was not set"; \
+          exit 1; \
+          fi
+          if [[ -z "$RUN_NUMBER_OFFSET" ]]; then \
+          echo "::error::Variable RUN_NUMBER_OFFSET was not set"; \
+          exit 1; \
+          fi
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+
       # Offset our version build number to prevent collisions
       - name: Offset Build Number
         id: offset
         run: |
           echo "BUILD_NUMBER=$(($RUN_NUMBER + $RUN_NUMBER_OFFSET))" >> "$GITHUB_OUTPUT"
+
       # Upgrade Docker engine version, needed for building images.
       - name: Install Latest Docker Version
         run: |
@@ -47,6 +71,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
+
+      # Authenticate GHCR to allow pushing to our alternate image registry
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Checkout our Github repo
       - name: Checkout Github Repo
@@ -67,6 +99,7 @@ jobs:
         run: |
           cd ${REPO_DIR}
           echo "VERSION=$(sed -n 's/^VERSION ?= //p' Makefile | cut -d '$' -f 1)" >> $GITHUB_OUTPUT
+
       # Compile Vault and Build Docker Images
       - name: Compile and Build Docker Images
         run: |
@@ -80,10 +113,11 @@ jobs:
       # Push Docker Images to Dockerhub
       - name: Push Image to Dockerhub
         run: |
-          docker push ${IMAGE_REPO}/${IMAGE_NAME}:${VERSION}
           if [[ $GITHUB_REF == 'refs/heads/master' ]]; then \
           docker tag ${IMAGE_REPO}/${IMAGE_NAME}:${VERSION} ${IMAGE_REPO}/${IMAGE_NAME}:testing && \
           docker push ${IMAGE_REPO}/${IMAGE_NAME}:testing; \
+          docker tag ${IMAGE_REPO}/${IMAGE_NAME}:${VERSION} ${GITHUB_CONTAINER_REGISTRY}/${IMAGE_NAME}:testing && \
+          docker push ${GITHUB_CONTAINER_REGISTRY}/${IMAGE_NAME}:testing; \
           fi
         env:
           VERSION: '${{ steps.config-version.outputs.VERSION }}-${{ steps.offset.outputs.BUILD_NUMBER }}'


### PR DESCRIPTION
…ainer registry, Stop pushing semantic version to dockerhub

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- Updated our GH action workflow to stop pushing semantic version tagged images to Dockerhub.
- Updated our GH action workflow to push our testing tagged images to GitHub container registry.
- Updated out GH action workflow to check and ensure repository variables and secrets are set before running

**Necessary Repository Settings**
_Found in: Repo Settings -> Actions -> General_

- Workflow permissions
   - `Read and write permissions` should be selected here, this gives our ephemeral `GITHUB_TOKEN` default secret access to push to ghcr.


Fixes #60 