### PR TITLE
Replace ubi9-minimal on ubi9-micro for docker build image

### DIFF
--- a/docker/Dockerfile.ubi.amd64
+++ b/docker/Dockerfile.ubi.amd64
@@ -1,4 +1,8 @@
-FROM registry.access.redhat.com/ubi9-minimal:latest
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="The secrets vault."
@@ -13,6 +17,17 @@ ARG VAULT_VERSION
 ARG VAULT_GPGKEY
 ARG ARCH
 ARG VAULT_PLUGIN_HASH
+
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
 
 # Create a vault user and group first so the IDs get set the same way.
 
@@ -46,6 +61,7 @@ RUN set -eux; \
     gpgconf --kill dirmngr && \
     gpgconf --kill gpg-agent  && \
     rm -rf /root/.gnupg  && \
+    microdnf install -y curl &&\
     microdnf clean all
 
 # /vault/logs is made available to use as a location to store audit logs


### PR DESCRIPTION
Use ubi-micro instead of ubi-minimal to reduce the threat surface attack area.

<img width="1065" alt="Screenshot 2025-01-14 at 07 46 38" src="https://github.com/user-attachments/assets/f35b8371-ade6-4b8e-b80e-397b57bc44b1" />

```
"architecture": "x86_64",
"build-date": "2025-01-09T12:46:01Z",
"com.redhat.component": "ubi9-micro-container",
"com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
"description": "The vault manages secrets used by applications deployed to edge nodes.",
"distribution-scope": "public",
"io.buildah.version": "1.38.0-dev",
"io.k8s.description": "Very small image which doesn't install the package manager.",
"io.k8s.display-name": "Red Hat Universal Base Image 9 Micro",
"io.openshift.expose-services": "",
"maintainer": "Red Hat, Inc.",
"name": "amd64_vault",
"release": "048e47d",
"summary": "The secrets vault.",
"url": "https://www.redhat.com",
"vault_version": "1.14.8",
"vcs-ref": "0bf50525dc8ce0b1f0fb83b0d10a826d8c769a89",
"vcs-type": "git",
"vendor": "IBM",
"version": "1.1.6"
```